### PR TITLE
Use TLSv1 instead of SSLv3 to connect to provider

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -250,7 +250,7 @@ module Ovirt
 
     def resource_options
       headers = merge_headers({ 'Prefer' => 'persistent-auth' })
-      options = { :ssl_version => :SSLv3 }
+      options = { :ssl_version => 'TLSv1' }
 
       if self.session_id
         headers[:cookie]     = "#{SESSION_ID_KEY}=#{self.session_id}"


### PR DESCRIPTION
SSLv3 is being phased out due to POODLE attack

ovirt was moved from manageiq repo. Originally ManageIQ/manageiq#958
