### PR TITLE
Use Latest version of rest-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
-gem "rest-client", "~>1.6.7", :require => false, :git => "git://github.com/ManageIQ/rest-client.git", :tag => "v1.6.7-5"
-
 # Specify your gem's dependencies in ovirt.gemspec
 gemspec

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "more_core_extensions"
   spec.add_dependency "nokogiri"
   spec.add_dependency "parallel"
-  spec.add_dependency "rest-client", "~>1.6.7"
+  spec.add_dependency "rest-client", "~>1.7.2"
 end


### PR DESCRIPTION
`ssl_version` is now part of rest-client

(commit has many more details for future debugging)

This was previous in ManageIQ/manageiq#946
