### PR TITLE
let library determine proper SSL transport

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -250,7 +250,7 @@ module Ovirt
 
     def resource_options
       headers = merge_headers({ 'Prefer' => 'persistent-auth' })
-      options = { :ssl_version => 'TLSv1' }
+      options = {}
 
       if self.session_id
         headers[:cookie]     = "#{SESSION_ID_KEY}=#{self.session_id}"


### PR DESCRIPTION
fixes issues when connecting to a server that disabled SSLv3

https://bugzilla.redhat.com/show_bug.cgi?id=1159114
