### PR TITLE
Use URI to build URIs and hostname= to wrap ipv6 addresses in brackets.

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -241,11 +241,10 @@ module Ovirt
     end
 
     def base_uri
-      if port.blank?
-        "#{scheme}://#{server}"
-      else
-        "#{scheme}://#{server}:#{port}"
-      end
+      require 'uri'
+      uri = URI::Generic.build(:scheme => scheme.to_s, :port => port)
+      uri.hostname = server
+      uri.to_s
     end
 
     def resource_options

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -27,4 +27,39 @@ EOX
       expect { @service.resource_post('uri', 'data') }.to raise_error(Ovirt::Error, error_detail)
     end
   end
+
+  context "#base_uri" do
+    let(:defaults) { {:username => nil, :password => nil}}
+    subject { described_class.new(defaults.merge(@options)).send(:base_uri) }
+
+    it "ipv4" do
+      @options = {:server => "127.0.0.1"}
+      subject.should == "https://127.0.0.1:443"
+    end
+
+    it "ipv6" do
+      @options = {:server => "::1"}
+      subject.should == "https://[::1]:443"
+    end
+
+    it "hostname" do
+      @options = {:server => "nobody.com"}
+      subject.should == "https://nobody.com:443"
+    end
+
+    it "port 4443" do
+      @options = {:server => "nobody.com", :port => 4443}
+      subject.should == "https://nobody.com:4443"
+    end
+
+    it "blank port" do
+      @options = {:server => "nobody.com", :port => ""}
+      subject.should == "https://nobody.com"
+    end
+
+    it "nil port uses defaults" do
+      @options = {:server => "nobody.com", :port => nil}
+      subject.should == "https://nobody.com:443"
+    end
+  end
 end


### PR DESCRIPTION
See: https://bugs.ruby-lang.org/issues/3788
Related: https://www.ietf.org/rfc/rfc2732.txt
