### PR TITLE
Loosen rest-client dependency to allow for 2.0.0.

### DIFF
--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "more_core_extensions"
   spec.add_dependency "nokogiri"
   spec.add_dependency "parallel"
-  spec.add_dependency "rest-client", "~>1.7.2"
+  spec.add_dependency "rest-client", ">= 1.7.2"
 end


### PR DESCRIPTION
Specifically, rest-client 2.0 adds IPv6 support:
https://github.com/rest-client/rest-client/pull/332
https://github.com/rest-client/rest-client/pull/333