### PR TITLE
Use explicit namespace when referencing File class.

### DIFF
--- a/lib/ovirt/inventory.rb
+++ b/lib/ovirt/inventory.rb
@@ -77,7 +77,7 @@ module Ovirt
     end
 
     def get_vm(path)
-      vm_guid = File.basename(path, '.*')
+      vm_guid = ::File.basename(path, '.*')
       vm = get_resource_by_ems_ref("/api/vms/#{vm_guid}") rescue nil
       vm = get_resource_by_ems_ref("/api/templates/#{vm_guid}") if vm.blank?
       return vm

--- a/lib/ovirt/template.rb
+++ b/lib/ovirt/template.rb
@@ -62,7 +62,7 @@ module Ovirt
         storage_domain = disk[:storage_domains].first
         storage_id = storage_domain && storage_domain[:id]
         disk_key = disk[:image_id].blank? ? :id : :image_id
-        file_path = storage_id && File.join('/dev', storage_id, disk[disk_key])
+        file_path = storage_id && ::File.join('/dev', storage_id, disk[disk_key])
 
         tag = "scsi0:#{idx}"
         cfgHash["#{tag}.present"]    = "true"


### PR DESCRIPTION
The ovirt gem defines a File class in the Ovirt namespace, so any
reference to the standard Ruby File class must be fully qualified.

https://bugzilla.redhat.com/show_bug.cgi?id=1205247