### PR TITLE
Travis: drop rbx, add 2.2, jruby-head, and ruby-head.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: ruby
 rvm:
-  - "1.9.3"
-  - "2.0"
-  - "2.1"
-  - rbx-19mode
-install:
-  - bundle install --retry=3
+- "1.9.3"
+- "2.0"
+- "2.1"
+- "2.2"
+- ruby-head
+- jruby-head
+matrix:
+  allow_failures:
+  - rvm: ruby-head
+  - rvm: jruby-head
+  fast_finish: true


### PR DESCRIPTION
Allow failures on both jruby-head and ruby-head.