### PR TITLE
Add cloud init support

### DIFF
--- a/lib/ovirt/exception.rb
+++ b/lib/ovirt/exception.rb
@@ -10,4 +10,7 @@ module Ovirt
   class VmAlreadyRunning < Error; end
   class VmIsNotRunning   < Error; end
   class VmNotReadyToBoot < Error; end
+
+  class UsageError < Error; end
+  class CloudInitSyntaxError < UsageError; end
 end

--- a/lib/ovirt/legacy_support/cloud_init_via_floppy_payload.rb
+++ b/lib/ovirt/legacy_support/cloud_init_via_floppy_payload.rb
@@ -1,0 +1,7 @@
+module Ovirt
+  module CloudInitViaFloppyPayload
+    def cloud_init=(content)
+      attach_floppy("user-data.txt" => content)
+    end
+  end
+end

--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -240,8 +240,10 @@ module Ovirt
       doc    = Nokogiri::XML(response)
       action = doc.xpath("action").first
       node   = action || doc
-      reason = node.xpath("fault/detail").text
-      raise Ovirt::Error, reason
+      fault  = node.xpath("fault/detail").text
+      usage  = node.xpath("usage_message/message").text
+      raise Ovirt::Error, fault unless fault.blank?
+      raise Ovirt::UsageError, usage
     end
 
     def parse_set_cookie_header(set_cookie_header)

--- a/spec/factories/vm.rb
+++ b/spec/factories/vm.rb
@@ -1,7 +1,12 @@
 FactoryGirl.define do
-  factory :vm_full, :class => "Ovirt::Vm" do
+  factory :vm, :class => "Ovirt::Vm" do
+    initialize_with { new(service, {}) }
+    service { build(:service) }
+  end
+
+  factory :vm_full, :parent => :vm do
     initialize_with do
-      new(build(:service),
+      new(service,
         {
           :actions           => {:stop => '/api/vms/128f9ffd-b82c-41e4-8c00-9742ed173bac/stop'},
           :id                => "128f9ffd-b82c-41e4-8c00-9742ed173bac",

--- a/spec/legacy_support/cloud_init_via_floppy_payload_spec.rb
+++ b/spec/legacy_support/cloud_init_via_floppy_payload_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Ovirt::CloudInitViaFloppyPayload do
+  let(:vm) { build(:vm) }
+
+  it "cloud_init= Ovirt 3.3 and older" do
+    cloud_config = "#cloud_config\nroot_password: some_password\nregenerate_ssh_keys: false\ncustom_script: \"#!/bin/bash\necho 'hi'\""
+
+    expect(vm.service).to receive(:api).and_return(:product_info => {:version => {:major => "3", :minor => "3", :revision => "0", :build => "0"}})
+    expect(vm).to         receive(:attach_floppy).with("user-data.txt" => cloud_config)
+
+    vm.cloud_init = cloud_config
+  end
+end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -24,6 +24,24 @@ EOX
       service.stub(:create_resource).and_return(rest_client)
       expect { service.resource_post('uri', 'data') }.to raise_error(Ovirt::Error, error_detail)
     end
+
+    it "raises Ovirt::Error if HTTP 409 response code received" do
+      error_detail = "Usage message"
+      return_data = <<-EOX.chomp
+<usage_message>
+  <message>#{error_detail}</message>
+</usage_message>
+EOX
+
+      rest_client = double('rest_client').as_null_object
+      rest_client.should_receive(:post) do |&block|
+        return_data.stub(:code).and_return(409)
+        block.call(return_data)
+      end
+
+      service.stub(:create_resource).and_return(rest_client)
+      expect { service.resource_post('uri', 'data') }.to raise_error(Ovirt::UsageError, error_detail)
+    end
   end
 
   it "#resource_get on exception" do

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -232,13 +232,20 @@ EOX
   end
 
   it "cloud_init= Ovirt 3.4 and newer" do
-    cloud_config = "#cloud_config\nroot_password: some_password\nregenerate_ssh_keys: false\ncustom_script: \"#!/bin/bash\necho 'hi'\""
+    cloud_config = <<-EOCC.chomp
+#cloud_config
+regenerate_ssh_keys: false
+root_password: some_password
+fqdn: example.example.com
+debug: True
+EOCC
+
     expected_data = <<-EOX.chomp
 <vm>
   <initialization>
-    <root_password>some_password</root_password>
     <regenerate_ssh_keys>false</regenerate_ssh_keys>
-    <custom_script>#!/bin/bash echo 'hi'</custom_script>
+    <root_password>some_password</root_password>
+    <custom_script>fqdn: example.example.com\ndebug: true\n</custom_script>
   </initialization>
 </vm>
 EOX

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -230,4 +230,41 @@ EOX
       end
     end
   end
+
+  it "cloud_init= Ovirt 3.4 and newer" do
+    cloud_config = "#cloud_config\nroot_password: some_password\nregenerate_ssh_keys: false\ncustom_script: \"#!/bin/bash\necho 'hi'\""
+    expected_data = <<-EOX.chomp
+<vm>
+  <initialization>
+    <root_password>some_password</root_password>
+    <regenerate_ssh_keys>false</regenerate_ssh_keys>
+    <custom_script>#!/bin/bash echo 'hi'</custom_script>
+  </initialization>
+</vm>
+EOX
+
+    return_data = <<-EOX.chomp
+<vm href="/api/vms/128f9ffd-b82c-41e4-8c00-9742ed173bac" id="128f9ffd-b82c-41e4-8c00-9742ed173bac">
+  <name>bd-skeletal-clone-from-template</name>
+  <cpu>
+    <topology sockets="1" cores="1"/>
+  </cpu>
+  <os type="rhel_6x64">
+    <boot dev="hd"/>
+  </os>
+  <placement_policy>
+    <host id="a3abe9ed-fa52-4a7f-8a9b-1eebc782781f"/>
+    <affinity>migratable</affinity>
+  </placement_policy>
+  <memory_policy>
+    <guaranteed>1073741824</guaranteed>
+    <ballooning>true</ballooning>
+  </memory_policy>
+</vm>
+EOX
+
+    expect(service).to receive(:api).and_return(:product_info => {:version => {:major => "3", :minor => "4", :revision => "0", :build => "0"}})
+    expect(service).to receive(:resource_put).once.with(vm.attributes[:href], expected_data).and_return(return_data)
+    vm.cloud_init = cloud_config
+  end
 end


### PR DESCRIPTION
Move cloud_init configuration from ManageIQ to ovirt gem.  Allow for both newer and older styles of attaching cloud_init data.