### PR TITLE
Add logger with null_logger

### DIFF
--- a/lib/ovirt.rb
+++ b/lib/ovirt.rb
@@ -2,6 +2,8 @@ require 'active_support/all'
 require 'more_core_extensions/all'
 
 require 'ovirt/exception'
+require 'ovirt/logging'
+require 'ovirt/null_logger'
 require 'ovirt/base'
 require 'ovirt/version'
 
@@ -32,3 +34,13 @@ require 'ovirt/template'
 require 'ovirt/user'
 require 'ovirt/vm'
 require 'ovirt/vmpool'
+
+module Ovirt
+  class << self
+    attr_writer :logger
+  end
+
+  def self.logger
+    @logger ||= NullLogger.new
+  end
+end

--- a/lib/ovirt/base.rb
+++ b/lib/ovirt/base.rb
@@ -1,5 +1,8 @@
 module Ovirt
   class Base
+    extend Logging
+    include Logging
+
     def self.create_from_xml(service, xml)
       new(service, parse_xml(xml))
     end

--- a/lib/ovirt/event.rb
+++ b/lib/ovirt/event.rb
@@ -13,7 +13,7 @@ module Ovirt
       hash[:name] = EVENT_CODES[hash[:code]]
       unless hash[:name]
         hash[:name] = "UNKNOWN"
-        $rhevm_log.warn "MIQ(#{name}.#{__method__}) Unknown RHEVM event #{hash[:code]}: #{hash[:description]}"
+        logger.warn("#{name}.#{__method__} Unknown RHEVM event #{hash[:code]}: #{hash[:description]}")
       end
     end
     private_class_method :set_event_name

--- a/lib/ovirt/logging.rb
+++ b/lib/ovirt/logging.rb
@@ -1,0 +1,5 @@
+module Ovirt
+  module Logging
+    delegate :logger, :to => :Ovirt
+  end
+end

--- a/lib/ovirt/null_logger.rb
+++ b/lib/ovirt/null_logger.rb
@@ -1,0 +1,11 @@
+require 'logger'
+
+module Ovirt
+  class NullLogger < Logger
+    def initialize(*_args)
+    end
+
+    def add(*_args, &_block)
+    end
+  end
+end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -1,13 +1,5 @@
 describe Ovirt::Event do
   context ".set_event_name" do
-    before do
-      @orig_log, $rhevm_log = $rhevm_log, double("logger")
-    end
-
-    after do
-      $rhevm_log = @orig_log
-    end
-
     it "sets the name corresponding to a valid code" do
       hash = {:code => 1}
       described_class.send(:set_event_name, hash)
@@ -15,7 +7,7 @@ describe Ovirt::Event do
     end
 
     it "sets 'UNKNOWN' as the name with an invalid code" do
-      expect($rhevm_log).to receive :warn
+      expect(Ovirt.logger).to receive(:warn).with("Ovirt::Event.set_event_name Unknown RHEVM event -1: Invalid Code")
       hash = {:code => -1, :description => "Invalid Code"}
       described_class.send(:set_event_name, hash)
       expect(hash[:name]).to eq("UNKNOWN")


### PR DESCRIPTION
Based on changes in https://github.com/ManageIQ/ovirt/pull/33

Addresses rubocop complaints about $rhevm_log variable, also cleans up the code nicely

Followed the same pattern that we used in [AwesomeSpawn](https://github.com/ManageIQ/awesome_spawn/pull/23)