### PR TITLE
RestClient v2 properly returns codes 201 & 202, parse them normally

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -199,7 +199,7 @@ module Ovirt
       logger.debug "#{log_header}: With args: <#{args.inspect}>"
       resource.send(verb, *args) do |response, request, result, &block|
         case response.code
-        when 200
+        when 200..206
           parse_normal_response(response, resource)
         when 400, 409
           parse_error_response(response)


### PR DESCRIPTION
With the ManageIQ upgrade of RestClient to v2, it now properly returns response codes of 201 and 202 instead of returning the response as 200.

https://bugzilla.redhat.com/show_bug.cgi?id=1265466