### PR TITLE
Catch NoMethodError from RestClient in ovirt?

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -140,7 +140,7 @@ module Ovirt
     def self.ovirt?(options)
       options[:username] = options[:password] = "_unused"
       !new(options).engine_ssh_public_key.to_s.blank?
-    rescue RestClient::ResourceNotFound
+    rescue RestClient::ResourceNotFound, NoMethodError
       false
     end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -54,6 +54,11 @@ EOX
       expect(described_class.ovirt?(:server => "127.0.0.1")).to be false
     end
 
+    it "false when invalid content encoding returned" do
+      expect_any_instance_of(described_class).to receive(:engine_ssh_public_key).and_raise(NoMethodError)
+      expect(described_class.ovirt?(:server => "127.0.0.1")).to be false
+    end
+
     it "true when key non-empty" do
       fake_key = "ssh-rsa " + ("A" * 372) + " ovirt-engine\n"
       expect_any_instance_of(described_class).to receive(:engine_ssh_public_key).and_return(fake_key)


### PR DESCRIPTION
RestClient throws an exception trying to write to RestClient.log
when it receives an invalid encoding type from a server.  This
happens when running ovirt? against a VMware vCenter.

https://bugzilla.redhat.com/show_bug.cgi?id=1307153