### PR TITLE
separate fetch resource and collection using ems_ref

### DIFF
--- a/lib/ovirt/inventory.rb
+++ b/lib/ovirt/inventory.rb
@@ -87,6 +87,10 @@ module Ovirt
       @service.get_resource_by_ems_ref(uri_suffix, element_name)
     end
 
+    def get_resources_by_uri_path(uri_suffix, element_name = nil)
+      @service.get_resources_by_uri_path(uri_suffix, element_name)
+    end
+
     def refresh
       # TODO: Change to not return native objects to the caller.  The caller
       #       should just expect raw data.
@@ -157,7 +161,7 @@ module Ovirt
 
     def collect_primary_targeted_jobs(jobs)
       results = collect_in_parallel(jobs) do |key, ems_ref|
-        get_resource_by_ems_ref(ems_ref, key.to_s)
+        get_resources_by_uri_path(ems_ref, key.to_s)
       end
 
       jobs.zip(results).each_with_object({}) do |((key, _), result), hash|

--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -130,6 +130,14 @@ module Ovirt
       doc            = Nokogiri::XML(xml)
       element_name ||= doc.root.name
       klass          = self.class.name_to_class(element_name)
+      xml_to_object(klass, doc.root)
+    end
+
+    def get_resources_by_uri_path(uri_suffix, element_name = nil)
+      xml            = resource_get(uri_suffix)
+      doc            = Nokogiri::XML(xml)
+      element_name ||= doc.root.name
+      klass          = self.class.name_to_class(element_name)
       objects        = doc.xpath("//#{element_name}")
       objects.collect { |obj| xml_to_object(klass, obj) }
     end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -108,7 +108,7 @@ EOC
     expect { service.resource_get('api') }.to raise_error(Exception, "BLAH")
   end
 
-  context "#get_resource_by_ems_ref" do
+  context "#get_resources_by_uri_path" do
     it "fetches data_center" do
       return_message = <<-EOX.chomp
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -137,13 +137,13 @@ EOC
 EOX
       expect(service).to receive(:resource_get).and_return(return_message)
 
-      data_center = service.get_resource_by_ems_ref("/api/datacenters/00000001-0001-0001-0001-0000000000f1")
+      data_center = service.get_resources_by_uri_path("/api/datacenters/00000001-0001-0001-0001-0000000000f1")
       expect(data_center[0].name).to eq "Default"
     end
 
     it "returns 404" do
       expect(service).to receive(:resource_get).and_raise(Ovirt::MissingResourceError)
-      expect { service.get_resource_by_ems_ref("/api/vms/1234") }.to raise_error(Ovirt::MissingResourceError)
+      expect { service.get_resources_by_uri_path("/api/vms/1234") }.to raise_error(Ovirt::MissingResourceError)
     end
   end
 


### PR DESCRIPTION
Use separate methods to fetch single and collection of resources using ems_ref.

Fix for https://github.com/ManageIQ/manageiq/issues/8151