### PR TITLE
Use version 2.0.0.rc1 of rest-client

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -264,7 +264,7 @@ module Ovirt
         when 400..409
           parse_error_response(response, resource)
         else
-          response.return!(request, result, &block)
+          response.return!(&block)
         end
       end
     rescue RestClient::Unauthorized

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "more_core_extensions"
   spec.add_dependency "nokogiri"
   spec.add_dependency "parallel"
-  spec.add_dependency "rest-client", ">= 1.7.2"
+  spec.add_dependency "rest-client", ">= 2.0.0.rc1"
 end


### PR DESCRIPTION
This is the version used by ManageIQ itself, and is good to be in sync.
In addition this version of rest-client changed the signature of the
Request#return! method, so we need to change the way we call it,
otherwise unexpected response codes returned by the engine result in
exceptions and failed inventory refreshes, for example.

Bug-Url: https://bugzilla.redhat.com/1328087
Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>