### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+# Changes
+
+This document enumerates the changes made to the gem with each release.
+
+## 0.9.1 / Apr 28 2016
+
+Bug fixes:
+
+* Updated the gem to use version 2.0.0.rc1 of `rest-client` and adapted
+  for the changes that the new version requires.

--- a/lib/ovirt/version.rb
+++ b/lib/ovirt/version.rb
@@ -1,3 +1,3 @@
 module Ovirt
-  VERSION = "0.9.0"
+  VERSION = "0.9.1".freeze
 end


### PR DESCRIPTION
Release 0.9.1, containing fix to work correctly with version 2.0.0.rc1 of rest-client