### PR TITLE
Remove "ovirt-engine" prefix from paths

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -197,10 +197,17 @@ module Ovirt
     def api_uri(path = nil)
       # Calculate the complete URI:
       uri = URI.join(base_uri, api_path).to_s
+
+      # The path passed to this method will have the "/api" prefix if it comes from the "ems_ref"
+      # attribute stored in the database, and will have the "/ovirt-engine/api" if it comes directly
+      # from the "href" attribute of the XML documents, for example when using the "relationships"
+      # method to fetch secondary objects related to the primary object. This means that to have
+      # a clean path we need to remove both "ovirt-engine" and "api".
       unless path.nil?
         parts = path.to_s.split('/')
-        parts.shift if parts.first == ''    # Remove leading slash
-        parts.shift if parts.first == 'api' # We already have /api in our URI
+        parts.shift if parts.first == ''
+        parts.shift if parts.first == 'ovirt-engine'
+        parts.shift if parts.first == 'api'
         uri += "/#{parts.join('/')}" unless parts.empty?
       end
       uri

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -206,6 +206,29 @@ EOX
     end
   end
 
+  context "#api_uri" do
+    BASE_URI = "https://nobody.com"
+    API_PATH = "/ovirt-engine/api"
+
+    before do
+      expect(service).to receive(:base_uri).and_return(BASE_URI)
+      expect(service).to receive(:api_path).and_return(API_PATH)
+    end   
+
+    it "removes slash" do
+      expect(service.api_uri("/vms/123")).to eq("#{BASE_URI}#{API_PATH}/vms/123")
+    end
+
+    it "removes /api" do
+      expect(service.api_uri("/api/vms/123")).to eq("#{BASE_URI}#{API_PATH}/vms/123")
+    end
+
+    it "removes /ovirt-engine/api" do
+      expect(service.api_uri("/ovirt-engine/api/vms/123")).to eq("#{BASE_URI}#{API_PATH}/vms/123")
+    end
+
+  end
+
   context "#version" do
     it "with :full_version" do
       allow(service).to receive(:product_info).and_return(:full_version => "3.4.5-0.3.el6ev", :version => {:major => "3", :minor => "4", :build => "0", :revision => "0"})


### PR DESCRIPTION
The path passed to the "api_uri" method will have the "/api" prefix if it is
extracted from the "ems_ref" attribute stored in the database, and will have
the "/ovirt-engine/api" if it comes directly from the "href" attribute of the
XML documents, for example when using the "relationships" method to fetch
secondary objects related to the primary object. This means that to have a
clean path we need to remove both "ovirt-engine" and "api".

https://bugzilla.redhat.com/show_bug.cgi?id=1352967