### PR TITLE
Drop dependency on 'activesupport'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - "2.0"
 - "2.1"
-- "2.2"
+- "2.2.5"
 - "2.3.1"
 - ruby-head
 - jruby-head

--- a/lib/ovirt.rb
+++ b/lib/ovirt.rb
@@ -1,4 +1,3 @@
-require 'active_support/all'
 require 'more_core_extensions/all'
 
 require 'ovirt/exception'

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -26,14 +26,16 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
+  # Prevent factory_girl from installing activesupport v5 (incompatible with Ruby < 2.2.2)
+  spec.add_development_dependency "activesupport", "< 5"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "factory_girl", "~> 4.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",   "~> 3.0"
   spec.add_development_dependency "coveralls"
 
-  spec.add_dependency "activesupport"
-  spec.add_dependency "more_core_extensions"
+  spec.add_dependency "more_core_extensions", ">= 3.0.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "parallel"
   spec.add_dependency "rest-client", ">= 2.0.0.rc1"

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -13,9 +13,9 @@ describe Ovirt::Vm do
         :interface         => "virtio",
         :format            => "raw",
         :image_id          => "a791ba77-8cc1-44de-9945-69f0a291cc47",
-        :size              => 10_737_418_240,
-        :provisioned_size  => 10_737_418_240,
-        :actual_size       => 1_316_855_808,
+        :size              => 10_737_418_240, # 10.gigabytes
+        :provisioned_size  => 10_737_418_240, # 10.gigabytes
+        :actual_size       => 1_316_855_808,  # 1255.megabytes
         :sparse            => true,
         :bootable          => true,
         :wipe_after_delete => true,
@@ -169,7 +169,7 @@ EOX
 
   context "#memory_reserve" do
     it "updates the memory policy guarantee" do
-      memory_reserve = 1.gigabyte
+      memory_reserve = 1_073_741_824 # 1.gigabyte
       expected_data  = <<-EOX.chomp
 <vm>
   <memory_policy>


### PR DESCRIPTION
Rails 5 isn't compatible with older rubies.
Rather than dropping support for older rubies just for #blank?, we can
define #blank? if it isn't already defined.