### PR TITLE
Update Guaranteed memory when updating VM's memory

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -124,6 +124,10 @@ module Ovirt
 
     def memory=(value)
       update! do |xml|
+        xml.memory_policy do
+          xml.guaranteed(value)
+        end
+
         xml.memory value
       end
     end


### PR DESCRIPTION
There is a coupling between the Guaranteed memory to the VM memory:
Guaranteed cannot exceed the VM memory, and the VM memory cannot
be set to a lower value than the guaranteed memory.

The ovirt-engine UI behavior sets the same value for both memory
and guaranteed - this patch imitates the same behavior.

http://bugzilla.redhat.com/1356193