### PR TITLE
Require rest-client >= 2.0.0 and handle changes to exception.to_s

### DIFF
--- a/examples/inventory_example.rb
+++ b/examples/inventory_example.rb
@@ -26,7 +26,7 @@ def print_object(base, caption, indent = 0, recurse = true)
         puts "#{indentation}Ignoring #{rel} relationship due to ovirt error: #{err}"
       rescue RestClient::InternalServerError => err
         puts_caption(new_caption, indentation)
-        puts "#{indentation}Ignoring #{rel} relationship due to rest client error: #{err}"
+        puts "#{indentation}Ignoring #{rel} relationship due to rest client error: #{err.response}"
       end
     end
   end

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "more_core_extensions", ">= 3.0.0"
   spec.add_dependency "nokogiri"
   spec.add_dependency "parallel"
-  spec.add_dependency "rest-client", ">= 2.0.0.rc1"
+  spec.add_dependency "rest-client", ">= 2.0.0"
 end


### PR DESCRIPTION
Due to [this change](https://github.com/marios/rest-client/pull/1/commits/a5b0998fdcdd366bf35aff29dc1299faaabb790e#diff-eb43f38b5b854e38aa016f90e0ce30baL107) in RestClients exceptions, changing to use `response` for better detail.
```ruby
err.to_s
 => Ignoring statistics relationship due to rest client error: 500 Internal Server Error

err.message
 => Ignoring statistics relationship due to rest client error: 500 Internal Server Error

err.response
 => Ignoring statistics relationship due to rest client error: <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<fault>
    <reason>Operation Failed</reason>
</fault>
```