### PR TITLE
Fix discovery of version 4 of oVirt

### DIFF
--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -258,24 +258,24 @@ EOX
   end
 
   context "#api_uri" do
-    BASE_URI = "https://nobody.com"
-    API_PATH = "/ovirt-engine/api"
+    let(:base_uri) { "https://nobody.com" }
+    let(:api_path) { "/ovirt-engine/api" }
 
     before do
-      expect(service).to receive(:base_uri).and_return(BASE_URI)
-      expect(service).to receive(:api_path).and_return(API_PATH)
+      expect(service).to receive(:base_uri).and_return(base_uri)
+      expect(service).to receive(:api_path).and_return(api_path)
     end   
 
     it "removes slash" do
-      expect(service.api_uri("/vms/123")).to eq("#{BASE_URI}#{API_PATH}/vms/123")
+      expect(service.api_uri("/vms/123")).to eq("#{base_uri}#{api_path}/vms/123")
     end
 
     it "removes /api" do
-      expect(service.api_uri("/api/vms/123")).to eq("#{BASE_URI}#{API_PATH}/vms/123")
+      expect(service.api_uri("/api/vms/123")).to eq("#{base_uri}#{api_path}/vms/123")
     end
 
     it "removes /ovirt-engine/api" do
-      expect(service.api_uri("/ovirt-engine/api/vms/123")).to eq("#{BASE_URI}#{API_PATH}/vms/123")
+      expect(service.api_uri("/ovirt-engine/api/vms/123")).to eq("#{base_uri}#{api_path}/vms/123")
     end
 
   end


### PR DESCRIPTION
Currently this gem tests for the presence of the oVirt engine sending a
request to the following URL:

  http://.../engine.ssh.key.txt

This doesn't work with version 4 of the engine, as that path was
removed. In order to support older and newer versions of the engine this
patch modifies the gem so that it checks first the path that works since
version 3.5 of the engine, and then, if that doesn't work, the old path.

https://bugzilla.redhat.com/1382732