### PR TITLE
Support templates without OS

### DIFF
--- a/lib/ovirt/template.rb
+++ b/lib/ovirt/template.rb
@@ -27,7 +27,9 @@ module Ovirt
                        :attribute => [:type],
                        :node      => [:kernel, :initrd, :cmdline])
 
-      hash[:os][:boot_order] = boot_order = []
+      boot_order = []
+      hash[:os] = { :boot_order => boot_order }
+
       # Collect boot order
       node.xpath('os/boot').each do |boot|
         dev = boot['dev']


### PR DESCRIPTION
In case of a template without OS, the code to parse the OS fails:
hash[:os][:boot_order] = boot_order = []

The left part 'hash[:os][:boot_order]' fails since hash[:os]
is nil. However, the entire statement ends without an error due to
the assignment, but the 'boot_order' is declared without being initialized
to [], therefore its value is nil.

The parsing eventually fails with nil error when trying to add a value to
boot_order using << operator.

https://bugzilla.redhat.com/show_bug.cgi?id=1412573