### PR TITLE
Fix the `template[:os][:type]` being overwritten by boot_order

### DIFF
--- a/lib/ovirt/template.rb
+++ b/lib/ovirt/template.rb
@@ -28,7 +28,7 @@ module Ovirt
                        :node      => [:kernel, :initrd, :cmdline])
 
       boot_order = []
-      hash[:os] = { :boot_order => boot_order }
+      hash.store_path(:os, :boot_order, boot_order)
 
       # Collect boot order
       node.xpath('os/boot').each do |boot|


### PR DESCRIPTION
https://github.com/ManageIQ/ovirt/commit/4f6dd24042ed07771399c4744fe3d06dea010966 introduced an issue where the template os type information is overwritten.

Before assigning boot_order the `hash[:os]` looked like:
```
hash[:os]
{:type=>"rhel_6x64"}
```

And after it just had
```
hash[:os]
{:boot_order=>[]}
```

This is causing issues for the RHV refresh_parser which looks up the os type here: https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/redhat/infra_manager/refresh/parse/parser.rb#L583

This causes build errors: https://travis-ci.org/ManageIQ/manageiq/jobs/204227264#L696

Instead of overwriting the os hash, use store path to just set the `[:os][:boot_order]` key without overwriting anything already in `hash[:os]`.