### PR TITLE
RHV VM not retrieving FQDN

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -304,6 +304,9 @@ module Ovirt
         gi.xpath('ips/ip').each do |ip|
           ips << {:address => ip[:address]}
         end
+
+        fqdn = gi.xpath('fqdn').text
+        hash[:guest_info][:fqdn] = fqdn unless fqdn.blank?
       end
 
       hash


### PR DESCRIPTION
The PR adds the ability to retrieve the FQDN when it is reported by the
VM's guest agent.

https://bugzilla.redhat.com/show_bug.cgi?id=1417965