### PR TITLE
Fix handling of version 4.y in Vm.attach_payload

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -181,10 +181,9 @@ module Ovirt
     def payload_version
       version = service.version
 
-      if version[:major].to_i >= 3
-        return "3_0" if version[:minor].to_i < 3
-        return "3_3"
-      end
+      # Note that in this context "3_3" actually means 3.3 *or newer*, including 3.6 and 4.0.
+      return "3_0" if version[:major].to_i == 3 && version[:minor].to_i < 3
+      "3_3"
     end
 
     def attach_payload_3_0(payloads)

--- a/spec/vm_spec.rb
+++ b/spec/vm_spec.rb
@@ -484,4 +484,31 @@ EOX
       vm.cloud_init = cloud_config
     end
   end
+
+  context "#payload_version" do
+    it "returns 3_0 for version older than 3.3" do
+      expect(service).to receive(:version).and_return(:major => "3", :minor => "1")
+      expect(vm.payload_version).to eql("3_0")
+    end
+
+    it "returns 3_3 for version equal to 3.3" do
+      expect(service).to receive(:version).and_return(:major => "3", :minor => "3")
+      expect(vm.payload_version).to eql("3_3")
+    end
+
+    it "returns 3_3 for version 3.6" do
+      expect(service).to receive(:version).and_return(:major => "3", :minor => "6")
+      expect(vm.payload_version).to eql("3_3")
+    end
+
+    it "returns 3_3 for version 4.0" do
+      expect(service).to receive(:version).and_return(:major => "4", :minor => "0")
+      expect(vm.payload_version).to eql("3_3")
+    end
+
+    it "returns 3_3 for version 4.1" do
+      expect(service).to receive(:version).and_return(:major => "4", :minor => "1")
+      expect(vm.payload_version).to eql("3_3")
+    end
+  end
 end


### PR DESCRIPTION
The Vm.attach_payload method has two versions: one for oVirt older than
3.3, and another for oVirt 3.3 or newer. But the 'payloads_version' that
decides which one to use does not take into account that the major
version can be greater than 3. As a result when the major version is 4.0
it selects the version of the method for oVirt older than 3.3. This
patch fixes that issue.

https://bugzilla.redhat.com/1441746