### PR TITLE
Use 'application/xml' explicitly

### DIFF
--- a/lib/ovirt/service.rb
+++ b/lib/ovirt/service.rb
@@ -288,15 +288,15 @@ module Ovirt
       full_xml
     end
 
-    def resource_get(path = nil)
-      resource_verb(path, :get)
+    def resource_get(path = nil, additional_headers = {:accept => 'application/xml'})
+      resource_verb(path, :get, additional_headers)
     end
 
-    def resource_put(path, payload, additional_headers = {:content_type => :xml, :accept => :xml})
+    def resource_put(path, payload, additional_headers = {:content_type => 'application/xml', :accept => 'application/xml'})
       resource_verb(path, :put, payload, additional_headers)
     end
 
-    def resource_post(path, payload, additional_headers = {:content_type => :xml, :accept => :xml})
+    def resource_post(path, payload, additional_headers = {:content_type => 'application/xml', :accept => 'application/xml'})
       resource_verb(path, :post, payload, additional_headers)
     end
 


### PR DESCRIPTION
Currently this gem uses 'xml' as the values for the Content-Type and
Accept headers. That isn't a correct MIME type, but the rest-client gem
explicitly translates it into 'application/xml' using the services of
the 'mime-types' gem. But recently in the ManageIQ project the
'mime-types' gem has been replaced by 'mini_mime'. The net result is
that 'xml' is no longer translated into 'application/xml'. As a result
all the requests sent by this gem are rejected by the oVirt server. To
avoid this problem this patch changes this gem so that it sends
'application/xml' explicitly.

This patch addresses the following bug:

  Can't Provision Vm via V3 (using ovirt gem)
  https://bugzilla.redhat.com/1466417