### PR TITLE
Remove ActiveSupport reference

### DIFF
--- a/lib/ovirt/logging.rb
+++ b/lib/ovirt/logging.rb
@@ -1,5 +1,7 @@
 module Ovirt
   module Logging
-    delegate :logger, :to => :Ovirt
+    def logger
+      Ovirt.logger
+    end
   end
 end


### PR DESCRIPTION
The 'delegate' is an ActiveSupport feature which isn't include in the
ovirt gem requirements. It is being replaced with a simple method
definition in order to avoid adding ActiveSupport dependency.

Fixes issue https://github.com/ManageIQ/ovirt/issues/86