### PR TITLE
Refresh fails when placement policy not set

### DIFF
--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -292,7 +292,7 @@ module Ovirt
                        :node => [:affinity])
 
       parse_first_node_with_hash(node, 'placement_policy/host', hash[:placement_policy][:host] = {},
-                                 :attribute => [:id])
+                                 :attribute => [:id]) if hash.key?(:placement_policy)
 
       parse_first_node(node, :memory_policy, hash,
                        :node_to_i => [:guaranteed])


### PR DESCRIPTION
When a refresh is running a vm has no placement policy define the whole
refresh fails.

Bur-Url:
https://bugzilla.redhat.com/1513637