### PR TITLE
Fix export vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .bundle
 .config
 .idea
+.rubocop-*
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/examples/export_vm_example.rb
+++ b/examples/export_vm_example.rb
@@ -18,5 +18,6 @@ loop do
   status = rhevm.status(action)
   puts "STATUS: #{status.inspect}"
   break if status == 'complete'
+
   sleep 1
 end

--- a/examples/export_vm_example.rb
+++ b/examples/export_vm_example.rb
@@ -1,0 +1,22 @@
+require_relative './example_helper'
+
+STORAGE_DOMAIN_1 = raise "please define STORAGE_DOMAIN_1"
+VM_NAME          = raise "please define VM_NAME"
+
+rhevm = ExampleHelper.service
+
+sd1 = Ovirt::StorageDomain.find_by_name(rhevm, STORAGE_DOMAIN_1)
+puts "SD1: #{sd1.inspect}"
+
+vm = Ovirt::Vm.find_by_name(rhevm, VM_NAME)
+puts "VM: #{vm.inspect}"
+
+action = vm.export(sd1)
+puts "ACTION: #{action.inspect}"
+
+loop do
+  status = rhevm.status(action)
+  puts "STATUS: #{status.inspect}"
+  break if status == 'complete'
+  sleep 1
+end

--- a/lib/ovirt/base.rb
+++ b/lib/ovirt/base.rb
@@ -32,6 +32,7 @@ module Ovirt
       action = node.xpath('//action').first
 
       raise Ovirt::Error, "No Action in Response: #{response.inspect}" unless action
+
       action
     end
 
@@ -263,16 +264,20 @@ module Ovirt
       replace(self.class.find_by_href(@service, self[:href]))
     end
 
-    def method_missing(m, *args, &block)
-      if @relationships.key?(m)
-        relationship(m)
-      elsif @operations.key?(m)
-        operation(m, args, &block)
-      elsif @attributes.key?(m)
-        @attributes[m]
+    def method_missing(method_name, *args, &block)
+      if @relationships.key?(method_name)
+        relationship(method_name)
+      elsif @operations.key?(method_name)
+        operation(method_name, args, &block)
+      elsif @attributes.key?(method_name)
+        @attributes[method_name]
       else
         super
       end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      (@relationships.key?(method_name) || @operations.key?(method_name) || @attributes.key?(method_name)) || super
     end
 
     def operation(method, *_args)

--- a/lib/ovirt/base.rb
+++ b/lib/ovirt/base.rb
@@ -27,6 +27,14 @@ module Ovirt
       actions
     end
 
+    def self.response_to_action(response)
+      node = xml_to_nokogiri(response)
+      action = node.xpath('//action').first
+
+      raise Ovirt::Error, "No Action in Response: #{response.inspect}" unless action
+      action
+    end
+
     def self.hash_from_id_and_href(node)
       hash = {}
       [:id, :href].each { |key| hash[key] = node[key.to_s] unless node.nil? || node[key.to_s].nil? }
@@ -255,11 +263,11 @@ module Ovirt
       replace(self.class.find_by_href(@service, self[:href]))
     end
 
-    def method_missing(m, *args)
+    def method_missing(m, *args, &block)
       if @relationships.key?(m)
         relationship(m)
       elsif @operations.key?(m)
-        operation(m, args)
+        operation(m, args, &block)
       elsif @attributes.key?(m)
         @attributes[m]
       else

--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -63,7 +63,7 @@ module Ovirt
         xml.storage_domain(:id => self.class.object_to_id(storage_domain))
       end
 
-      self.class.response_to_action(response)['href'] 
+      self.class.response_to_action(response)['href']
     end
 
     def move(storage_domain)
@@ -82,8 +82,8 @@ module Ovirt
       #     <state>pending</state>
       #   </status>
       # </action>
-      
-      self.class.response_to_action(response)['href'] 
+
+      self.class.response_to_action(response)['href']
     end
 
     def boot_order=(devices)

--- a/lib/ovirt/vm.rb
+++ b/lib/ovirt/vm.rb
@@ -58,6 +58,14 @@ module Ovirt
       super
     end
 
+    def export(storage_domain)
+      response = operation(:export) do |xml|
+        xml.storage_domain(:id => self.class.object_to_id(storage_domain))
+      end
+
+      self.class.response_to_action(response)['href'] 
+    end
+
     def move(storage_domain)
       response = operation(:move) do |xml|
         xml.storage_domain(:id => self.class.object_to_id(storage_domain))
@@ -74,10 +82,8 @@ module Ovirt
       #     <state>pending</state>
       #   </status>
       # </action>
-      doc    = Nokogiri::XML(response)
-      action = doc.xpath("//action").first
-      raise Ovirt::Error, "No Action in Response: #{response.inspect}" if action.nil?
-      action['href']
+      
+      self.class.response_to_action(response)['href'] 
     end
 
     def boot_order=(devices)

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   # Prevent factory_girl from installing activesupport v5 (incompatible with Ruby < 2.2.2)
   spec.add_development_dependency "activesupport", "< 5"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "factory_girl", "~> 4.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",   "~> 3.0"

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls"
 
   spec.add_dependency "more_core_extensions", ">= 3.0.0"
-  spec.add_dependency "nokogiri", ">= 1.6.8"
+  spec.add_dependency "nokogiri", ">= 1.10.8"
   spec.add_dependency "rest-client", ">= 2.0.0"
 end


### PR DESCRIPTION
The export is now a new method of Vm object.
This PR fix also the block passing parameter in case of method_missing usage. So now it's possible to act as below

```ruby
response = vm.<operation> { |xml| xml.storage_domain { xml.name STORAGE_DOMAIN_1 } }
action = Ovirt::Vm.response_to_action(response)
```
Related to: https://github.com/ManageIQ/ovirt/issues/90