### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/ovirt.svg)](https://travis-ci.org/ManageIQ/ovirt)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/ovirt.svg)](https://codeclimate.com/github/ManageIQ/ovirt)
 [![Coverage Status](https://coveralls.io/repos/ManageIQ/ovirt/badge.svg)](https://coveralls.io/github/ManageIQ/ovirt)
-[![Dependency Status](https://gemnasium.com/ManageIQ/ovirt.svg)](https://gemnasium.com/ManageIQ/ovirt)
 [![Security](https://hakiri.io/github/ManageIQ/ovirt/master.svg)](https://hakiri.io/github/ManageIQ/ovirt/master)
 
 Ovirt provides a simple Object Oriented interface to the REST API of oVirt and RHEV-M servers.


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.