### PR TITLE
Update factory_bot to fix the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.5'
-        - '2.6'
-        - '2.7'
         - '3.0'
         - '3.1'
     env:

--- a/ovirt.gemspec
+++ b/ovirt.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rest-client", ">= 2.0.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "factory_bot", "~> 5.1"
+  spec.add_development_dependency "factory_bot", "~> 6.5"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",       "~> 3.0"


### PR DESCRIPTION
It is building with activesupport 7.2
FactoryBot 5.1 does not work with this version
FactoryBot 6.5 is more compatible

We can either:
1. peg to activesupport 7.0
2. allow activesupport 7.2 and require newer factorybot and newer ruby