### PR TITLE
Deprecate and archive the ovirt gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This gem has been deprecated and will no longer be updated
+
+This gem supports the oVirt v3 API and not the newer v4 API.  If you are looking for a ruby gem for oVirt v4 check out [ovirt-engine-sdk](https://rubygems.org/gems/ovirt-engine-sdk)
+
 # Ovirt
 
 [![Gem Version](https://badge.fury.io/rb/ovirt.svg)](http://badge.fury.io/rb/ovirt)


### PR DESCRIPTION
The ovirt gem only supports the V3 API which has been end of life for years.

Any new development using oVirt v4 should use the newer ovirt-engine-sdk https://rubygems.org/gems/ovirt-engine-sdk

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
